### PR TITLE
Fix tests

### DIFF
--- a/steganossaurus/binary_manipulation.py
+++ b/steganossaurus/binary_manipulation.py
@@ -34,10 +34,9 @@ def substitute_lsb(origin: int, new: str):
 
     if len(binary_origin) < len(new):
         raise ValueError(
-            f"""New value is too big to be encoded inside origin value.
-            Origin: {binary_origin}, new: {new} 
-        """
+            "New value is too big to be encoded inside origin value."
         )
+
     else:
         new_binary = binary_origin[: -len(new)] + new
         return int(new_binary, base=2)

--- a/tests/test_binary_operations.py
+++ b/tests/test_binary_operations.py
@@ -1,6 +1,6 @@
 import pytest
 
-from stegossaurus.binary_manipulation import substitute_lsb, extract_lsb
+from steganossaurus.binary_manipulation import substitute_lsb, extract_lsb
 
 def test_substitute_lsb():
     assert substitute_lsb(200, "11") == 203


### PR DESCRIPTION
Currently, two main reasons are causing the tests to fail
* `ImportError` when importing the `steganossaurus` module
* Divergence between an raised exception message and the message expected by the tests

This PR fix both problems. Changing the message when raising the exception to adapt to the one expected by the tests seemed the best approach, since the original message was too verbose and the one written in the tests looked best fitting.

Closes #2 